### PR TITLE
fix: clarify secret handling, correct Railway button domain, expand README intro

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
-NODE_RED_CREDENTIAL_SECRET=replace-with-long-random-secret
+# Set this in the Railway dashboard as a generated secret
+NODE_RED_CREDENTIAL_SECRET=
 NODE_RED_USERNAME=admin
-NODE_RED_PASSWORD=replace-with-strong-password
+# Set this in the Railway dashboard as a generated secret
+NODE_RED_PASSWORD=
 # Optional alternative to NODE_RED_PASSWORD
 # NODE_RED_PASSWORD_HASH=$2a$10$...
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Template Header](./template-header.svg)
 
 
-Deploy Node-RED on Railway with one click.
+Deploy Node-RED on Railway with one click. Node-RED is a flow-based low-code programming tool for wiring together hardware devices, APIs, and online services as part of the Internet of Things. This template runs it behind HTTPS with password authentication, a FlowFuse dashboard, and Railway config as code, so you can start building automations in minutes.
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/56bdr8?referralCode=2_sIT9)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/56bdr8?referralCode=2_sIT9)
 
 ## ✨ Features
 


### PR DESCRIPTION
## Summary
Addresses best-practice review findings for this template.

- **Naming**: `displayName: "Node-RED"` in `railway-template.json` left untouched — it's the official product name with a hyphen, not a real naming violation.
- **Env Vars / Auth**: `.env.example` comments for `NODE_RED_PASSWORD` and `NODE_RED_CREDENTIAL_SECRET` changed from bare placeholders to `# Set this in the Railway dashboard as a generated secret`, consistent with the other DB/service templates.
- **README**: Fixed the Deploy button and template link from `railway.app` to `railway.com` (`button.svg` and the template URL) for consistency with all other templates in this org. Expanded the intro from ~8 to ~50 words.
- **Changelog**: Already present — no change needed.

## Not solvable via code
- Binding `NODE_RED_PASSWORD` / `NODE_RED_CREDENTIAL_SECRET` to Railway-generated `secret()` values happens in the Railway dashboard/template config, not in this repo. Needs to be set manually when the template is deployed/updated in Railway → tracked on the completion checklist.

## Test plan
- [ ] Click through the updated Deploy button link to confirm it resolves correctly on railway.com


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q714FWFhvmuo6m9qwttrTP)_