### PR TITLE
docs: add architecture diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Deploy Node-RED on Railway with one click. Node-RED is a flow-based low-code pro
 * FlowFuse Dashboard via `@flowfuse/node-red-dashboard`
 * Railway config as code via `railway.toml`
 
+## 🏗️ Architecture
+
+```mermaid
+flowchart LR
+    Client(["🌐 Client"]) -->|HTTPS| Domain["Railway Public Domain"]
+    Domain -->|"$PORT"| App["Container (Railpack build)\nnode-red -u /data"]
+    App --> Volume[("Volume\n/data")]
+```
+
 ## Production recommendations (Railway)
 
 * Keep credentials in Railway Variables, never in `.env` committed to Git


### PR DESCRIPTION
## Summary
- Adds a Mermaid diagram to the README showing this template's deployed architecture: Railway public domain → container (Railpack build, `node-red -u /data`) → persistent volume.
- No functional changes.

## Test plan
- [x] Verified the Mermaid block renders (fenced ```mermaid, GitHub-native rendering).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WwCVWpdDxXTCW5fYFbyCRw)_